### PR TITLE
fix: fill AR pipeline devices[] before AR_PROFILE alloc

### DIFF
--- a/patches/12-hybrid-allreduce-hip.patch
+++ b/patches/12-hybrid-allreduce-hip.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000..16238b32a
 --- /dev/null
 +++ b/ggml/src/ggml-cuda/allreduce-hip.cu
-@@ -0,0 +1,1564 @@
+@@ -0,0 +1,1567 @@
 +#include "allreduce.cuh"
 +
 +#if defined(GGML_USE_HIP)
@@ -796,6 +796,12 @@ index 000000000..16238b32a
 +        GGML_LOG_WARN("%s: host-side lockstep pacing enabled (GGML_CUDA_AR_PACE=1); "
 +                      "poll peers' prev AR before enqueueing (WIP)\n", __func__);
 +    }
++    // devices[] must be filled before any per-device hipMalloc. Profile
++    // alloc used p->devices[] while it was still zero, so every buffer
++    // landed on GPU 0 and MTP's second pipeline hung GPU 1 (gfx1201).
++    for (size_t i = 0; i < n_devices; ++i) {
++        p->devices[i] = devices[i];
++    }
 +    p->prof_enabled     = ggml_cuda_ar_env_u64("GGML_CUDA_AR_PROFILE", 0) != 0;
 +    if (p->prof_enabled) {
 +        GGML_LOG_WARN("%s: per-call profiling enabled (GGML_CUDA_AR_PROFILE=1); "
@@ -811,9 +817,6 @@ index 000000000..16238b32a
 +                return nullptr;
 +            }
 +        }
-+    }
-+    for (size_t i = 0; i < n_devices; ++i) {
-+        p->devices[i] = devices[i];
 +    }
 +
 +    // Per-device streams and event pools.


### PR DESCRIPTION
`GGML_CUDA_AR_PROFILE=1` + MTP on 2× gfx1201 hung GPU 1 at the **second** `ggml_cuda_ar_pipeline_init` (draft context). Same recipe without the flag loaded.

**Cause:** `new ggml_cuda_ar_pipeline{}` zero-fills `p->devices[]`. Profile `hipMalloc` ran before the copy from the caller list, so every prof buffer landed on device 0.

**Fix:** copy `devices[]` first, then allocate. One reorder in block 12 (`allreduce-hip.cu`). Default serving (profiler off) is unchanged.

Not issue #6 (bounded spin / MES freeze). Same file, different bug.

**Lab (2× R9700, Qwen 3.8 27B Q8, tensor 1,1, internal AR, MTP n-max3, `-c 98304`):**
- 8k: two profiler inits + n=32 completion + teardown dumps on **dev0 and dev1**
- ~73.6k prefill + 256 decode: 831 pp / 48.4 tg, no hang
- 80,041 prefill + 256 decode: 810 pp / 44.3 tg, dumps on both GPUs, no `GPU Hang` / reset in dmesg

Do not ship `AR_PROFILE=1` as a daily env. This only makes the debug flag safe.