### PR TITLE
perf: MTP chunked GDN prefix + sequential snapshot tail

### DIFF
--- a/benchmarks/2026-08-31-mtp-gdn-chunked-prefix.md
+++ b/benchmarks/2026-08-31-mtp-gdn-chunked-prefix.md
@@ -1,0 +1,29 @@
+# 2026-08-31 — MTP chunked GDN prefix (block 13)
+
+Credit: block 02 chunked WMMA GDN is stew675. This patch only runs it on MTP prefills.
+
+**Lab:** 2× R9700 (gfx1201), ROCm 7.14, tensor-split 1,1, `GGML_CUDA_ALLREDUCE=internal`, Qwen 3.8 27B Q8, ubatch 1024, MTP n-max 3 (`K=4`), FA on. Path fire: `MTP chunked GDN prefix n=1024 K=4 prefix=1020`.
+
+## Prefill tok/s (median of 3, `n_predict=16`, VOID=false)
+
+| prompt tokens | before (K==1-only chunked) | after (prefix+tail) |
+|--|--|--|
+| ~4141 | ~1441 | **1526–1527** (+5.9%) |
+| 40960 | 1160 | **1254** |
+| 81920 | 984 | **1043** |
+| 102400 | 911 | **960** (spread 0.03%, no cliff) |
+
+4k decode-32 ~78 both (not the win). 100k decode-16 ~46.5–46.8 both.
+
+## vs sequential (`GGML_CUDA_GDN_CHUNKED=0`, same binary)
+
+Token identity (greedy, temp 0): **not identical** — first diverge at token 6 (4k) / 11 (8k). Expected: bf16 chunked vs fp32 sequential.
+
+| task | prefix KEEP | sequential |
+|--|--|--|
+| GSM8K 50, max_tokens 256 | 19/50 | 18/50 |
+| HumanEval 20 | 20/20 | 20/20 |
+
+GSM8K +1 is noise. HE-20 is a ceiling.
+
+Opt out: `GGML_CUDA_GDN_CHUNKED=0`.

--- a/patches/13-mtp-gdn-chunked-prefix.patch
+++ b/patches/13-mtp-gdn-chunked-prefix.patch
@@ -1,0 +1,151 @@
+diff --git a/ggml/src/ggml-cuda/gated_delta_net.cu b/ggml/src/ggml-cuda/gated_delta_net.cu
+index 2b7abfd47..f9da81722 100644
+--- a/ggml/src/ggml-cuda/gated_delta_net.cu
++++ b/ggml/src/ggml-cuda/gated_delta_net.cu
+@@ -346,6 +346,55 @@ static void ggml_cuda_op_gated_delta_net_impl(
+         }
+     }
+ 
++    // MTP (K > 1) needs snapshot slots, so the K==1 fused-cache chunked path
++    // cannot cover it. Long single-sequence prefill: chunked GDN on the prefix
++    // (n_tokens - K), sequential GDN only on the last K tokens so slots 0..K-1
++    // stay correct. n_seqs > 1 stays fully sequential — the chunked n_tokens
++    // override is also the sequence stride. Opt out with GGML_CUDA_GDN_CHUNKED=0.
++    if (!kda && K > 1 && n_seqs == 1 && n_tokens > (int64_t) K + 64 &&
++        (S_v == 16 || S_v == 32 || S_v == 64 || S_v == 128)) {
++        const char * env = getenv("GGML_CUDA_GDN_CHUNKED");
++        if (env == nullptr || strcmp(env, "0") != 0) {
++            const int64_t n_prefix = n_tokens - K;
++            ggml_cuda_pool_alloc<float> prefix_state(ctx.pool(), (size_t) H * S_v * S_v * n_seqs);
++            bool prefix_ok = false;
++#if defined(GGML_USE_HIP) && defined(__HIP_PLATFORM_AMD__)
++            const int cc_p = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
++            const bool bf16_rdna_p = GGML_CUDA_CC_IS_RDNA4(cc_p) || GGML_CUDA_CC_IS_RDNA3(cc_p);
++            const char * envb_p = getenv("GGML_CUDA_GDN_CHUNKED_BF16");
++            const bool want_bf16_p = bf16_rdna_p && S_v == 128 &&
++                (envb_p == nullptr || strcmp(envb_p, "0") != 0);
++            if (want_bf16_p) {
++                if (GGML_CUDA_CC_IS_RDNA4(cc_p)) {
++                    prefix_ok = ggml_cuda_op_gated_delta_net_chunked_bf16(ctx, dst, prefix_state.get(), n_prefix);
++                } else {
++                    prefix_ok = ggml_cuda_op_gated_delta_net_chunked_bf16_gfx11(ctx, dst, prefix_state.get(), n_prefix);
++                }
++            } else
++#endif
++            {
++                prefix_ok = ggml_cuda_op_gated_delta_net_chunked(ctx, dst, prefix_state.get(), n_prefix);
++            }
++            if (prefix_ok) {
++                static bool logged_prefix = false;
++                if (!logged_prefix) {
++                    GGML_LOG_INFO("%s: MTP chunked GDN prefix n=%ld K=%d prefix=%ld\n",
++                                  __func__, (long) n_tokens, K, (long) n_prefix);
++                    logged_prefix = true;
++                }
++                float * state_d = cache ? cache->data : (dst_d + S_v * H * n_tokens * n_seqs);
++                const int64_t state_slot_stride = cache ? cache->slot_stride : (S_v * S_v * H * n_seqs);
++                launch_gated_delta_net<false, true>(
++                    q_d + n_prefix * sq2, k_d + n_prefix * sq2, v_d + n_prefix * sv2,
++                    g_d + n_prefix * sb2, b_d + n_prefix * sb2, prefix_state.get(),
++                    dst_d + n_prefix * S_v * H, state_d,
++                    S_v, H, K, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++                    sb1, sb2, sb3, neqk1, rq3, scale, state_slot_stride, K, stream);
++                return;
++            }
++        }
++    }
++
+     // recurrent state -> gdn_out tail (after attention scores), or the cache when fusing
+     float * state_d           = dst_d + S_v * H * n_tokens * n_seqs;
+     int64_t state_slot_stride = S_v * S_v * H * n_seqs;
+diff --git a/ggml/src/ggml-cuda/gated_delta_net_chunked.cu b/ggml/src/ggml-cuda/gated_delta_net_chunked.cu
+index 235522647..542675440 100644
+--- a/ggml/src/ggml-cuda/gated_delta_net_chunked.cu
++++ b/ggml/src/ggml-cuda/gated_delta_net_chunked.cu
+@@ -633,7 +633,7 @@ static bool launch_gdn_chunked(
+     }
+ }
+ 
+-bool ggml_cuda_op_gated_delta_net_chunked(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext) {
++bool ggml_cuda_op_gated_delta_net_chunked(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext, int64_t n_tokens_limit) {
+     ggml_tensor * src_q     = dst->src[0];
+     ggml_tensor * src_k     = dst->src[1];
+     ggml_tensor * src_v     = dst->src[2];
+@@ -651,7 +651,7 @@ bool ggml_cuda_op_gated_delta_net_chunked(ggml_backend_cuda_context & ctx, ggml_
+ 
+     const int64_t S_v      = nev0;
+     const int64_t H        = nev1;
+-    const int64_t n_tokens = nev2;
++    const int64_t n_tokens = (n_tokens_limit > 0 && n_tokens_limit < nev2) ? n_tokens_limit : nev2;
+     const int64_t n_seqs   = nev3;
+ 
+     GGML_ASSERT(neq1 == nek1);
+diff --git a/ggml/src/ggml-cuda/gated_delta_net_chunked.cuh b/ggml/src/ggml-cuda/gated_delta_net_chunked.cuh
+index 52e711c8a..993fa47de 100644
+--- a/ggml/src/ggml-cuda/gated_delta_net_chunked.cuh
++++ b/ggml/src/ggml-cuda/gated_delta_net_chunked.cuh
+@@ -39,7 +39,9 @@ static __inline__ bool ggml_cuda_kernel_launch_try(Kernel kernel, const ggml_cud
+ // Both chunked ops return true when their kernels were accepted for launch (or skipped by a
+ // GDN_DBG_* env hook) and false when a launch was rejected; the dispatcher then falls back
+ // to the sequential gated_delta_net kernel.
+-bool ggml_cuda_op_gated_delta_net_chunked(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext = nullptr);
++// n_tokens_limit > 0: process only the first n_tokens_limit tokens (MTP prefix).
++// Safe only when n_seqs == 1 — n_tokens is also the sequence stride.
++bool ggml_cuda_op_gated_delta_net_chunked(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext = nullptr, int64_t n_tokens_limit = 0);
+ 
+ // bf16/WMMA tensor-core variant (S_v == 128 only; near-lossless: PPL +0.056% / KL 0.0036 on
+ // wikitext-2 vs the fp32 path). DEFAULT for S_v == 128 on the HIP build (opt out with
+@@ -50,7 +52,7 @@ bool ggml_cuda_op_gated_delta_net_chunked(ggml_backend_cuda_context & ctx, ggml_
+ //     kernel, restored verbatim (chunked-gdn tip 99bbd1b20, 46/46 on gfx1201).
+ //   gated_delta_net_chunked_bf16_gfx11.cu - gfx11 (RDNA3/RDNA3.5): the first-gen WMMA port
+ //     (16 bf16/lane, validated on gfx1100), on its own path.
+-bool ggml_cuda_op_gated_delta_net_chunked_bf16(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext = nullptr);
++bool ggml_cuda_op_gated_delta_net_chunked_bf16(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext = nullptr, int64_t n_tokens_limit = 0);
+ 
+ // gfx11 (RDNA3/RDNA3.5) first-gen WMMA variant - same contract as the gfx12 entry above.
+-bool ggml_cuda_op_gated_delta_net_chunked_bf16_gfx11(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext = nullptr);
++bool ggml_cuda_op_gated_delta_net_chunked_bf16_gfx11(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext = nullptr, int64_t n_tokens_limit = 0);
+diff --git a/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16.cu b/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16.cu
+index 29facd203..6285a67db 100644
+--- a/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16.cu
++++ b/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16.cu
+@@ -902,7 +902,7 @@ static bool launch_gdn_bf16_scan(
+         neqk1_magic, rq3_magic, scale, state_seq_stride, dbg);
+ }
+ 
+-bool ggml_cuda_op_gated_delta_net_chunked_bf16(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext) {
++bool ggml_cuda_op_gated_delta_net_chunked_bf16(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext, int64_t n_tokens_limit) {
+     ggml_tensor * src_q     = dst->src[0];
+     ggml_tensor * src_k     = dst->src[1];
+     ggml_tensor * src_v     = dst->src[2];
+@@ -919,7 +919,7 @@ bool ggml_cuda_op_gated_delta_net_chunked_bf16(ggml_backend_cuda_context & ctx,
+ 
+     const int64_t S_v      = nev0;
+     const int64_t H        = nev1;
+-    const int64_t n_tokens = nev2;
++    const int64_t n_tokens = (n_tokens_limit > 0 && n_tokens_limit < nev2) ? n_tokens_limit : nev2;
+     const int64_t n_seqs   = nev3;
+ 
+     GGML_ASSERT(neq1 == nek1);
+diff --git a/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16_gfx11.cu b/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16_gfx11.cu
+index 910c99594..41d16bc0c 100644
+--- a/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16_gfx11.cu
++++ b/ggml/src/ggml-cuda/gated_delta_net_chunked_bf16_gfx11.cu
+@@ -918,7 +918,7 @@ static bool launch_gdn_bf16_scan(
+         neqk1_magic, rq3_magic, scale, state_seq_stride, dbg);
+ }
+ 
+-bool ggml_cuda_op_gated_delta_net_chunked_bf16_gfx11(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext) {
++bool ggml_cuda_op_gated_delta_net_chunked_bf16_gfx11(ggml_backend_cuda_context & ctx, ggml_tensor * dst, float * state_d_ext, int64_t n_tokens_limit) {
+     ggml_tensor * src_q     = dst->src[0];
+     ggml_tensor * src_k     = dst->src[1];
+     ggml_tensor * src_v     = dst->src[2];
+@@ -935,7 +935,7 @@ bool ggml_cuda_op_gated_delta_net_chunked_bf16_gfx11(ggml_backend_cuda_context &
+ 
+     const int64_t S_v      = nev0;
+     const int64_t H        = nev1;
+-    const int64_t n_tokens = nev2;
++    const int64_t n_tokens = (n_tokens_limit > 0 && n_tokens_limit < nev2) ? n_tokens_limit : nev2;
+     const int64_t n_seqs   = nev3;
+ 
+     GGML_ASSERT(neq1 == nek1);

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # rdna-boosts patch set (delivery)
 
-12 patches against the llama.cpp fork point `a7cc83bba`
+13 patches against the llama.cpp fork point `a7cc83bba`
 ("rpc: avoid serializing buffers from other servers (#26500)"; re-based
 2026-08-30 from `17252c769`):
 
@@ -18,6 +18,7 @@
 | `0010` | k-quant-boosts: Q4_K/Q5_K/Q6_K/Q8_0 mmvq VDR (+ q8_1 quantize-cache fusions) |
 | `0011` | skip CUDA graphs for multi-token PRE-FILL |
 | `0012` | **hybrid HIP all-reduce (block 12)** — the custom internal AR; hybrid dispatch; RDNA4-only gate |
+| `0013` | **MTP chunked GDN prefix** — chunked WMMA on `n_tokens-K`, sequential only on last K snapshots |
 
 ## Apply (fresh checkout at the fork point)
 
@@ -25,6 +26,7 @@
 git checkout a7cc83bba          # or: git apply each patch on a matching tree
 git am patches/000[1-9]-*.patch patches/001[01]-*.patch
 git apply patches/12-hybrid-allreduce-hip.patch
+git apply patches/13-mtp-gdn-chunked-prefix.patch
 ```
 
 (`git am` for the 1-11 series — plain `git apply` of the concatenated series
@@ -32,6 +34,17 @@ was observed to silently drop hunks; use `git am`.)
 
 The set is **whitespace-clean**: applying produces no git whitespace
 warnings (verified 2026-08-29 after the whitespace-clean regeneration).
+
+## Block 13 notes
+
+MTP `K > 1` used to skip block 02's chunked GDN (snapshots). Long
+single-sequence prefill now runs chunked WMMA on the prefix (`n_tokens-K`)
+and sequential GDN only on the last K tokens so slots `0..K-1` stay
+correct. Fused-cache graphs (`cache != nullptr`) are included. `n_seqs > 1`
+stays fully sequential. Opt out: `GGML_CUDA_GDN_CHUNKED=0`.
+
+Not bit-identical vs sequential (same as block 02 bf16 chunked: near-lossless,
+not exact). Lab numbers: `benchmarks/2026-08-31-mtp-gdn-chunked-prefix.md`.
 
 ## Block 12 notes
 

--- a/scripts/apply-all.sh
+++ b/scripts/apply-all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Apply the full rdna-boosts patch set (blocks 01-11 + the hybrid block 12)
+# Apply the full rdna-boosts patch set (blocks 01-11 + hybrid block 12 + MTP GDN prefix 13)
 # to a clean llama.cpp checkout at the recorded baseline.
 #
 # Usage: ./apply-all.sh [llama.cpp-checkout] [rdna-boosts-repo]
@@ -12,6 +12,7 @@
 # hunks -- verified 2026-08-29), one commit each with the block subject.
 # Block 12 (the hybrid HIP all-reduce) is applied with `git apply` and
 # committed as "rdna-boosts: block 12: hybrid HIP all-reduce".
+# Block 13 (MTP chunked-GDN prefix + sequential snapshot tail) is the same.
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -30,6 +31,7 @@ BLOCKS="0001-rdna-boosts-block-01-adaptive-MTP-draft-depth.patch \
 0010-rdna-boosts-block-10-k-quant-boosts-Q4_K-Q5_K-Q6_K-Q.patch \
 0011-rdna-boosts-block-11-skip-CUDA-graphs-for-multi-toke.patch"
 BLOCK12="12-hybrid-allreduce-hip.patch"
+BLOCK13="13-mtp-gdn-chunked-prefix.patch"
 
 cd "$LLAMA"
 
@@ -57,8 +59,14 @@ git add -A
 git commit -q -m "rdna-boosts: block 12: hybrid HIP all-reduce (RDNA4-gated)"
 echo "   committed"
 
+echo "== $BLOCK13"
+git apply "$PATCHES/$BLOCK13"
+git add -A
+git commit -q -m "rdna-boosts: block 13: MTP chunked GDN prefix + sequential snapshot tail"
+echo "   committed"
+
 echo
-N_BLOCKS=12
+N_BLOCKS=13
 echo "All $N_BLOCKS patches applied and committed on branch $BRANCH:"
 git log --oneline -$N_BLOCKS
 echo


### PR DESCRIPTION
Block 02's chunked WMMA GDN only launches when `K==1` (no MTP snapshots). With MTP n-max 3 (`K=4`) every prefill ubatch stayed on the **sequential** kernel. rocprof on a ~4k wrap put that sequential GDN at **10.45%**.

**Change (block 13, after 12):** long single-sequence prefill, `K>1`, `n_tokens > K+64`:
1. chunked GDN on the prefix (`n_tokens − K`)
2. sequential GDN only on the last K tokens so slots `0..K-1` stay correct
3. fused-cache graphs included (`cache != nullptr`) — without this the path never fires under MTP

`n_seqs > 1` stays fully sequential (chunked `n_tokens` is also the sequence stride). Opt out: `GGML_CUDA_GDN_CHUNKED=0`.

Credit stew675 for the chunked kernel. This is the dispatcher so it actually runs on MTP prefills.

**Lab (2× R9700 gfx1201, ROCm 7.14, Qwen 3.8 27B Q8, tensor 1,1, internal AR, ubatch 1024, MTP n-max 3, FA on).** Path fire: `n=1024 K=4 prefix=1020`.

Prefill tok/s (median of 3, `n_predict=16`, VOID=false):

| prompt tokens | before (K==1-only chunked) | after |
|--|--|--|
| ~4141 | ~1441 | **1526–1527** (+5.9%) |
| 40960 | 1160 | **1254** |
| 81920 | 984 | **1043** |
| 102400 | 911 | **960** (spread 0.03%, no cliff) |

4k decode-32 ~78 both. Not a decode win.

vs sequential (`GGML_CUDA_GDN_CHUNKED=0`, same binary): greedy token identity is **not** identical (diverge at token 6 / 11). Same class as block 02 bf16 chunked (near-lossless, not bit-exact). GSM8K 50: 19/50 vs 18/50. HumanEval 20: 20/20 both.

More numbers: `benchmarks/2026-08-31-mtp-gdn-chunked-prefix.md`.