### PR TITLE
block 08: don't fuse mul_mat + add through a view when the add's shape differs

### DIFF
--- a/patches/0008-rdna-boosts-block-08-fused-core-prefill-kernels-and-.patch
+++ b/patches/0008-rdna-boosts-block-08-fused-core-prefill-kernels-and-.patch
@@ -1,4 +1,4 @@
-From 75a06c310b2175f5f14c1ed72b4f2beebe561c58 Mon Sep 17 00:00:00 2001
+From 912b2c23a0fec5b284a2b75b2da4f949170dde15 Mon Sep 17 00:00:00 2001
 From: Stew Forster <stew675@gmail.com>
 Date: Sat, 29 Aug 2026 08:14:24 -0500
 Subject: [PATCH 08/13] rdna-boosts: block 08: fused-core prefill kernels and
@@ -8,14 +8,14 @@ Subject: [PATCH 08/13] rdna-boosts: block 08: fused-core prefill kernels and
  ggml/src/ggml-cuda/common.cuh     |  87 ++++
  ggml/src/ggml-cuda/fattn-tile.cuh |  16 +
  ggml/src/ggml-cuda/fattn.cu       |   5 +-
- ggml/src/ggml-cuda/ggml-cuda.cu   | 527 ++++++++++++++++++++++-
+ ggml/src/ggml-cuda/ggml-cuda.cu   | 544 +++++++++++++++++++++++-
  ggml/src/ggml-cuda/mmvq.cu        | 670 +++++++++++++++++++++++++++---
  ggml/src/ggml-cuda/mmvq.cuh       |  23 +
  ggml/src/ggml-cuda/norm.cu        | 215 ++++++++++
  ggml/src/ggml-cuda/norm.cuh       |   7 +
  ggml/src/ggml-cuda/unary.cu       | 150 +++++++
  ggml/src/ggml-cuda/unary.cuh      |   6 +
- 10 files changed, 1638 insertions(+), 68 deletions(-)
+ 10 files changed, 1655 insertions(+), 68 deletions(-)
 
 diff --git a/ggml/src/ggml-cuda/common.cuh b/ggml/src/ggml-cuda/common.cuh
 index 603c27d69..fcfb6488b 100644
@@ -173,7 +173,7 @@ index 3036829bb..5097310cf 100644
          if (logit_softcap == 0.0f || Q->ne[0] == 128 || Q->ne[0] == 256 || Q->ne[0] == 512) {
              return BEST_FATTN_KERNEL_MMA_F16;
 diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
-index 58e37af2b..1667a25b4 100644
+index 58e37af2b..40fbadb80 100644
 --- a/ggml/src/ggml-cuda/ggml-cuda.cu
 +++ b/ggml/src/ggml-cuda/ggml-cuda.cu
 @@ -711,6 +711,10 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
@@ -433,7 +433,7 @@ index 58e37af2b..1667a25b4 100644
      fused_mul_mat_vec = false;
      fused_node_count  = 0;
  
-@@ -4072,28 +4285,216 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4072,28 +4285,233 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          return fused_node_count - 1;
      }
  
@@ -639,6 +639,23 @@ index 58e37af2b..1667a25b4 100644
 +
 +        // the add reads the matmul output directly, or through the view
 +        ggml_tensor * mm_or_view = has_view ? cgraph->nodes[i + 1] : mm_node;
++
++        // The mmvq/mmvf fusion kernels are told to write into bias_node, but the
++        // shape checks below (and ggml_cuda_should_fuse_mul_mat_vec_*) look at
++        // mm_node. Without a view those are the same tensor. With one they are not:
++        // a reshape can move the tokens between dimensions, so a matmul that looks
++        // like a single-column GEMV (ne = [n,1,2]) can be paired with an add whose
++        // destination is ne = [n,2,1]. The kernels index the destination by ne[1]
++        // and ne[2] and assert on exactly this. Require the destination to satisfy
++        // the same constraint the kernels assert.
++        if (has_view) {
++            const ggml_tensor * ids_node = mm_node->src[2];
++            if (( ids_node && bias_node->ne[2] != 1) ||
++                (!ids_node && bias_node->ne[1] != 1)) {
++                continue;
++            }
++        }
++
  
          ggml_tensor * bias_tensor = nullptr;
          if (bias_op == GGML_OP_ADD) {
@@ -657,7 +674,7 @@ index 58e37af2b..1667a25b4 100644
                  continue;
              }
              bias_tensor = bias_node->src[1];
-@@ -4117,14 +4518,14 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4117,14 +4535,14 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          if (ggml_cuda_should_fuse_mul_mat_vec_f(mm_node)) {
              ggml_cuda_mul_mat_vec_f(*cuda_ctx, src0, src1, ids, bias_node, &fusion_data);
              fused_mul_mat_vec = true;
@@ -674,7 +691,7 @@ index 58e37af2b..1667a25b4 100644
              break;
          }
      }
-@@ -4153,6 +4554,96 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4153,6 +4571,96 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          return 1;
      }
  
@@ -771,7 +788,7 @@ index 58e37af2b..1667a25b4 100644
      if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_SSM_CONV, GGML_OP_ADD, GGML_OP_UNARY }, { GGML_UNARY_OP_SILU })) {
          ggml_cuda_op_ssm_conv(*cuda_ctx, node, cgraph->nodes[i + 1], cgraph->nodes[i + 2]);
          return 2;
-@@ -4166,7 +4657,18 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4166,7 +4674,18 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
      if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_UNARY, GGML_OP_MUL }, { GGML_UNARY_OP_SILU }) ||
          ggml_cuda_can_fuse(cgraph, i, { GGML_OP_UNARY, GGML_OP_MUL }, { GGML_UNARY_OP_SIGMOID }) ||
          ggml_cuda_can_fuse(cgraph, i, { GGML_OP_UNARY, GGML_OP_MUL }, { GGML_UNARY_OP_SOFTPLUS })) {
@@ -791,7 +808,7 @@ index 58e37af2b..1667a25b4 100644
          return 1;
      }
  
-@@ -4504,6 +5006,9 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
+@@ -4504,6 +5023,9 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
  
      ggml_cuda_set_device(cuda_ctx->device);
  
@@ -2117,5 +2134,5 @@ index 04f3af644..2a8c2e20c 100644
  
  __device__ __forceinline__ float ggml_cuda_op_silu_single(float x) {
 -- 
-2.55.0
+2.53.0.windows.2
 

--- a/rdna-boosts-all.patch
+++ b/rdna-boosts-all.patch
@@ -6370,7 +6370,7 @@ index 000000000..944110792
 +#endif // GGML_USE_HIP && __HIP_PLATFORM_AMD__
 \ No newline at end of file
 diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
-index 45e9537f0..f96e67bb4 100644
+index 45e9537f0..e2f8a9707 100644
 --- a/ggml/src/ggml-cuda/ggml-cuda.cu
 +++ b/ggml/src/ggml-cuda/ggml-cuda.cu
 @@ -72,6 +72,7 @@
@@ -7128,7 +7128,7 @@ index 45e9537f0..f96e67bb4 100644
      fused_mul_mat_vec = false;
      fused_node_count  = 0;
  
-@@ -4066,28 +4515,218 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4066,28 +4515,235 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          return fused_node_count - 1;
      }
  
@@ -7336,6 +7336,23 @@ index 45e9537f0..f96e67bb4 100644
 +
 +        // the add reads the matmul output directly, or through the view
 +        ggml_tensor * mm_or_view = has_view ? cgraph->nodes[i + 1] : mm_node;
++
++        // The mmvq/mmvf fusion kernels are told to write into bias_node, but the
++        // shape checks below (and ggml_cuda_should_fuse_mul_mat_vec_*) look at
++        // mm_node. Without a view those are the same tensor. With one they are not:
++        // a reshape can move the tokens between dimensions, so a matmul that looks
++        // like a single-column GEMV (ne = [n,1,2]) can be paired with an add whose
++        // destination is ne = [n,2,1]. The kernels index the destination by ne[1]
++        // and ne[2] and assert on exactly this. Require the destination to satisfy
++        // the same constraint the kernels assert.
++        if (has_view) {
++            const ggml_tensor * ids_node = mm_node->src[2];
++            if (( ids_node && bias_node->ne[2] != 1) ||
++                (!ids_node && bias_node->ne[1] != 1)) {
++                continue;
++            }
++        }
++
  
          ggml_tensor * bias_tensor = nullptr;
          if (bias_op == GGML_OP_ADD) {
@@ -7354,7 +7371,7 @@ index 45e9537f0..f96e67bb4 100644
                  continue;
              }
              bias_tensor = bias_node->src[1];
-@@ -4111,14 +4750,14 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4111,14 +4767,14 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          if (ggml_cuda_should_fuse_mul_mat_vec_f(mm_node)) {
              ggml_cuda_mul_mat_vec_f(*cuda_ctx, src0, src1, ids, bias_node, &fusion_data);
              fused_mul_mat_vec = true;
@@ -7371,7 +7388,7 @@ index 45e9537f0..f96e67bb4 100644
              break;
          }
      }
-@@ -4147,6 +4786,96 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4147,6 +4803,96 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          return 1;
      }
  
@@ -7468,7 +7485,7 @@ index 45e9537f0..f96e67bb4 100644
      if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_SSM_CONV, GGML_OP_ADD, GGML_OP_UNARY }, { GGML_UNARY_OP_SILU })) {
          ggml_cuda_op_ssm_conv(*cuda_ctx, node, cgraph->nodes[i + 1], cgraph->nodes[i + 2]);
          return 2;
-@@ -4160,7 +4889,18 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4160,7 +4906,18 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
      if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_UNARY, GGML_OP_MUL }, { GGML_UNARY_OP_SILU }) ||
          ggml_cuda_can_fuse(cgraph, i, { GGML_OP_UNARY, GGML_OP_MUL }, { GGML_UNARY_OP_SIGMOID }) ||
          ggml_cuda_can_fuse(cgraph, i, { GGML_OP_UNARY, GGML_OP_MUL }, { GGML_UNARY_OP_SOFTPLUS })) {
@@ -7488,7 +7505,7 @@ index 45e9537f0..f96e67bb4 100644
          return 1;
      }
  
-@@ -4174,12 +4914,60 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
+@@ -4174,12 +4931,60 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph
          return 2;
      }
  
@@ -7549,7 +7566,7 @@ index 45e9537f0..f96e67bb4 100644
      // flag used to determine whether it is an integrated_gpu
      const bool integrated            = ggml_cuda_info().devices[cuda_ctx->device].integrated;
  
-@@ -4317,9 +5105,19 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
+@@ -4317,9 +5122,19 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
                      continue;
                  }
  
@@ -7569,7 +7586,7 @@ index 45e9537f0..f96e67bb4 100644
  #ifdef GGML_CUDA_DEBUG
                      const int last_fused = i + nodes_to_skip;
                      GGML_LOG_INFO("nodes_fused: %d, first: %s (%s), last: %s (%s)\n",
-@@ -4329,6 +5127,7 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
+@@ -4329,6 +5144,7 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
                      i += nodes_to_skip;
                      continue;
                  }
@@ -7577,7 +7594,7 @@ index 45e9537f0..f96e67bb4 100644
  #ifndef NDEBUG
                  // On integrated GPUs (APUs, e.g. RDNA3.5) the scheduler may place a
                  // node's output on the host-visible buffer, which the compute path
-@@ -4346,12 +5145,21 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
+@@ -4346,12 +5162,21 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
                  GGML_UNUSED(integrated);
  #endif  // NDEBUG
  
@@ -7599,7 +7616,7 @@ index 45e9537f0..f96e67bb4 100644
                  if (!is_concurrent_event_active) {
                      try_launch_concurrent_event(node);
                 }
-@@ -4366,6 +5174,18 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
+@@ -4366,6 +5191,18 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
                  graph->graph = nullptr;
              }
  
@@ -7618,7 +7635,7 @@ index 45e9537f0..f96e67bb4 100644
              CUDA_CHECK(cudaStreamEndCapture(cuda_ctx->stream(), &graph->graph));
              graph_evaluated_or_captured = true; // CUDA graph has been captured
  
-@@ -4393,6 +5213,59 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
+@@ -4393,6 +5230,59 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
          graph_evaluated_or_captured = true;
  #endif  // USE_CUDA_GRAPH
      }
@@ -7678,7 +7695,7 @@ index 45e9537f0..f96e67bb4 100644
  }
  
  #ifdef USE_CUDA_GRAPH
-@@ -4417,19 +5290,34 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
+@@ -4417,19 +5307,34 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
  
      ggml_cuda_set_device(cuda_ctx->device);
  
@@ -7714,7 +7731,7 @@ index 45e9537f0..f96e67bb4 100644
              const bool properties_changed = ggml_cuda_graph_update_required(cuda_ctx, cgraph);
  
              if (!graph->warmup_complete) {
-@@ -4452,6 +5340,7 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
+@@ -4452,6 +5357,7 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
                      cuda_graph_update_required = graph->instance == nullptr;
                  }
              }


### PR DESCRIPTION
## What this fixes

Block 08's `mul_mat + add` fusion **through a view node** can hand the mmvq/mmvf
kernels a destination whose shape it never checked, which aborts the process:

```
ggml/src/ggml-cuda/mmvq.cu: GGML_ASSERT(ids || dst->ne[1] == 1) failed
```

On Windows this surfaces as `0xc0000409` in `ucrtbase.dll`, which looks like a
memory error but is just `abort()` from `GGML_ASSERT` — it cost us a while to
stop chasing an OOM that was never there.

## Why it happens

`ggml_cuda_should_fuse_mul_mat_vec_*` is evaluated on `mm_node`, but `bias_node`
is what the kernel is told to write into. Without a view those are the same
tensor, so the existing guard is sound. With a view they are not, because a
reshape can move tokens across dimensions. Straight from an instrumented crash:

```
dst  'attn_residual-0'      op=ADD   ne=[5120,2,1,1]
src0 'blk.0.ssm_out.weight' q8_0     ne=[6144,5120,1,1]
src1 'final_output-0'                ne=[6144,1,2,1]   ids=(null)
```

The matmul is `ne = [5120,1,2]` — two tokens on dim 2, so `ne[1] == 1` and the
guard passes it as a single-column GEMV. The add it feeds is `ne = [5120,2,1]`,
the same two tokens on dim 1. The kernels index the destination by `ne[1]`/`ne[2]`
and assert on exactly that.

Two tokens land in one batch as soon as **two sequences contribute to the same
batch** — `-np 2 --kv-unified` with both slots prefilling. Single-sequence decode
never produces this shape, which is why the fusion measured fine.

## The fix

Before fusing through a view, require the destination to satisfy the same
constraint the kernels assert. Single-sequence behaviour is unchanged.

## How it was found and verified

Found by instrumenting every mmvq fusion site with an id plus a shape dump
before the asserts, so the first crash named the site instead of needing a
bisect over the fusion sites.

Reproduced by replaying a captured pair of concurrent requests against
`llama-server` (Qwen3.8-27B, hybrid SSM+attention, `-np 2 --kv-unified`, both
slots prefilling long prompts):

| arm | crashes |
|---|---|
| unpatched, fusion on | **4 / 4** |
| that one fusion site masked off | 0 / 3 |
| **this fix, fusion fully on** | **0 / 3** |

- **Perplexity: bit-identical** (1.8577, and the per-chunk fingerprint matches
  exactly). Expected — `llama-perplexity` submits whole chunks, so those matmuls
  never reach the GEMV path.
- **Decode speed:** measured against the workaround we were running
  (`GGML_CUDA_DISABLE_FUSION=1`, which disables every fusion site): **+1.19 %**
  in favour of this fix, i.e. it recovers what disabling all fusion cost us.
  18 runs, 3 visits x 3 iterations per arm, arms interleaved, separate server
  instances, normalised for speculative-decoding acceptance (raw `gen_tps` is
  useless here — MTP acceptance swung 48-70 % between iterations).
- Deployed to our production server since 2026-09-07.

## Caveats, please read

- **`AGENTS.md` says to regenerate from the fork and run the coherence gate.**
  I did regenerate with `scripts/make-patches.sh` (I could not use your fork
  checkout, so I rebuilt the 13 blocks at `465e49b9c` from this repo's own
  patch set, folded the fix into block 08 and replayed 09-13). I then verified
  a clean-apply simulation: fresh checkout at `465e49b9c` + `scripts/apply-all.sh`
  applies all 13 blocks with the modified set.
- **I did not run the coherence gate** — no multi-GPU host here. Our hardware is
  a single R9700 (gfx1201), so `-sm tensor -mg 0` is not something I can
  exercise. Please run it before merging.
- Only `patches/0008-…` and `rdna-boosts-all.patch` are in the diff. Regenerating
  also rewrote the `From` hash and the git version trailer in the other blocks;
  that is pure noise, so I reverted those files.
- The same bug is present under different hashes in `stew675/llama.cpp`
  (`rdna-boosts-orig`, `chunked-gdn`), if you want to carry the fix there too.

Happy to adjust anything — including re-cutting this as a hand-edit of block 08
alone if you would rather keep the block commit hashes stable.
